### PR TITLE
feat: oauth support

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,26 @@
+# Letterboxd OAuth Demo
+
+This demo spins up a small Node server that serves a static page for testing the complete authorization-code + PKCE flow against the Letterboxd OAuth endpoints.
+
+## Prerequisites
+
+- Node.js ≥ 18
+- A Letterboxd API key/secret with a redirect URI pointing at `http://localhost:4173`
+
+## Usage
+
+```bash
+npm run demo
+```
+
+This command builds the SDK (so the server can require `dist/index.js`) and then launches the demo on <http://localhost:4173>.
+
+### Flow
+
+1. Enter your API key/secret, redirect URI, and desired scopes.
+2. Click **Start OAuth Flow**. The page will generate PKCE values, persist them to `sessionStorage`, and redirect you to Letterboxd’s consent page.
+3. After approving, you’ll land back on the demo page with a `code` query param. The page automatically exchanges the code via the SDK and shows the resulting payload.
+4. Use **Refresh Access Token** to try the refresh grant with the returned `refresh_token`.
+5. Use **Clear Session** to wipe all in-memory data.
+
+> API secrets only ever live in your browser tab’s `sessionStorage` and are never persisted to disk. Close the tab and they disappear.

--- a/demo/public/index.html
+++ b/demo/public/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Letterboxd OAuth Demo</title>
+    <link rel="stylesheet" href="/style.css" />
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Letterboxd OAuth Demo</h1>
+        <p>Walk through the full authorization-code + PKCE flow and copy the resulting API token.</p>
+      </header>
+
+      <section>
+        <h2>1. Configure</h2>
+        <form id="oauth-form">
+          <label>
+            API Key
+            <input type="text" name="apiKey" autocomplete="off" required />
+          </label>
+
+          <label>
+            API Secret
+            <input type="password" name="apiSecret" autocomplete="off" required />
+          </label>
+
+          <label>
+            Redirect URI
+            <input type="url" name="redirectUri" placeholder="http://localhost:4173" required />
+          </label>
+
+          <label>
+            Authorization Endpoint
+            <input type="url" name="authorizeUrl" value="https://letterboxd.com/oauth/authorize" required />
+          </label>
+
+          <label>
+            Scope (space separated)
+            <input type="text" name="scope" placeholder="read write" />
+          </label>
+
+          <div class="actions">
+            <button type="submit">Start OAuth Flow</button>
+          </div>
+        </form>
+        <p class="hint">
+          Heads up: credentials live only in this tab (sessionStorage) and are cleared when you close it.
+        </p>
+      </section>
+
+      <section id="status-panel">
+        <h2>2. Status</h2>
+        <div id="status-log"></div>
+      </section>
+
+      <section id="token-panel" hidden>
+        <h2>3. Token</h2>
+        <textarea id="token-output" readonly rows="10"></textarea>
+        <div class="actions">
+          <button id="refresh-token" type="button">Refresh Access Token</button>
+          <button id="clear-session" type="button">Clear Session</button>
+        </div>
+      </section>
+    </main>
+
+    <script type="module" src="/main.js"></script>
+  </body>
+</html>

--- a/demo/public/main.js
+++ b/demo/public/main.js
@@ -1,0 +1,244 @@
+/* eslint-env browser */
+
+const SESSION_KEY = 'letterboxd-oauth-demo/session';
+const PREF_KEY = 'letterboxd-oauth-demo/prefs';
+const DEFAULT_AUTHORIZE_URL = 'https://letterboxd.com/oauth/authorize';
+
+const form = document.getElementById('oauth-form');
+const statusLog = document.getElementById('status-log');
+const tokenPanel = document.getElementById('token-panel');
+const tokenOutput = document.getElementById('token-output');
+const refreshButton = document.getElementById('refresh-token');
+const clearButton = document.getElementById('clear-session');
+
+function log(message, isError = false) {
+  const entry = document.createElement('span');
+  entry.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+  if (isError) {
+    entry.style.color = '#ff7676';
+  }
+
+  statusLog.prepend(entry);
+}
+
+function savePreferences(prefs) {
+  localStorage.setItem(PREF_KEY, JSON.stringify(prefs));
+}
+
+function loadPreferences() {
+  const stored = localStorage.getItem(PREF_KEY);
+  if (!stored) return;
+
+  try {
+    const prefs = JSON.parse(stored);
+    form.apiKey.value = prefs.apiKey ?? '';
+    form.redirectUri.value = prefs.redirectUri ?? '';
+    form.authorizeUrl.value = prefs.authorizeUrl ?? DEFAULT_AUTHORIZE_URL;
+    form.scope.value = prefs.scope ?? '';
+  } catch (err) {
+    console.warn('Unable to load saved preferences', err); // eslint-disable-line no-console
+  }
+}
+
+function saveSession(session) {
+  sessionStorage.setItem(SESSION_KEY, JSON.stringify(session));
+}
+
+function loadSession() {
+  const stored = sessionStorage.getItem(SESSION_KEY);
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(stored);
+  } catch (err) {
+    console.warn('Unable to parse session payload', err); // eslint-disable-line no-console
+    return null;
+  }
+}
+
+function clearSession(message = 'Session cleared.') {
+  sessionStorage.removeItem(SESSION_KEY);
+  tokenPanel.hidden = true;
+  tokenOutput.value = '';
+  log(message);
+}
+
+function base64UrlEncode(data) {
+  const binary = Array.from(data, byte => String.fromCharCode(byte)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function createPkcePair() {
+  const random = new Uint8Array(64);
+  crypto.getRandomValues(random);
+
+  const codeVerifier = base64UrlEncode(random);
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(codeVerifier));
+  const codeChallenge = base64UrlEncode(new Uint8Array(digest));
+
+  return { codeVerifier, codeChallenge };
+}
+
+function buildAuthorizationUrl({ apiKey, authorizeUrl, redirectUri, codeChallenge, scope, state }) {
+  const url = new URL(authorizeUrl || DEFAULT_AUTHORIZE_URL);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', apiKey);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+
+  if (scope) {
+    url.searchParams.set('scope', scope.trim());
+  }
+
+  if (state) {
+    url.searchParams.set('state', state);
+  }
+
+  return url.toString();
+}
+
+async function exchangeAuthorizationCode(code, returnedState) {
+  const session = loadSession();
+  if (!session) {
+    log('Cannot exchange code because session data is missing.', true);
+    return;
+  }
+
+  if (session.state && returnedState && session.state !== returnedState) {
+    log('State mismatch detected. Aborting exchange.', true);
+    return;
+  }
+
+  log('Exchanging authorization code for tokens...');
+
+  const response = await fetch('/api/exchange', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      apiKey: session.apiKey,
+      apiSecret: session.apiSecret,
+      code,
+      codeVerifier: session.codeVerifier,
+      redirectUri: session.redirectUri,
+    }),
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    log(payload.error || 'Failed to exchange authorization code.', true);
+    return;
+  }
+
+  tokenPanel.hidden = false;
+  tokenOutput.value = JSON.stringify(payload, null, 2);
+  log('Success! Access token ready.');
+
+  saveSession({
+    ...session,
+    codeVerifier: undefined,
+    state: undefined,
+    refreshToken: payload.refresh_token,
+  });
+}
+
+async function refreshAccessToken() {
+  const session = loadSession();
+  if (!session?.refreshToken) {
+    log('No refresh token available for this session.', true);
+    return;
+  }
+
+  log('Refreshing access token...');
+
+  const response = await fetch('/api/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      apiKey: session.apiKey,
+      apiSecret: session.apiSecret,
+      refreshToken: session.refreshToken,
+    }),
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok) {
+    log(payload.error || 'Unable to refresh token.', true);
+    return;
+  }
+
+  tokenOutput.value = JSON.stringify(payload, null, 2);
+  log('Access token refreshed.');
+
+  saveSession({
+    ...session,
+    refreshToken: payload.refresh_token ?? session.refreshToken,
+  });
+}
+
+form.addEventListener('submit', async event => {
+  event.preventDefault();
+
+  const apiKey = form.apiKey.value.trim();
+  const apiSecret = form.apiSecret.value.trim();
+  const redirectUri = form.redirectUri.value.trim();
+  const authorizeUrl = form.authorizeUrl.value.trim() || DEFAULT_AUTHORIZE_URL;
+  const scope = form.scope.value.trim();
+
+  if (!apiKey || !apiSecret || !redirectUri) {
+    log('Please provide API key, secret, and redirect URI.', true);
+    return;
+  }
+
+  savePreferences({ apiKey, redirectUri, authorizeUrl, scope });
+
+  const pkce = await createPkcePair();
+  const state = crypto.randomUUID();
+
+  saveSession({
+    apiKey,
+    apiSecret,
+    redirectUri,
+    authorizeUrl,
+    codeVerifier: pkce.codeVerifier,
+    state,
+    scope,
+  });
+
+  const authorizationUrl = buildAuthorizationUrl({
+    apiKey,
+    authorizeUrl,
+    redirectUri,
+    codeChallenge: pkce.codeChallenge,
+    scope,
+    state,
+  });
+
+  log('Redirecting to Letterboxd for authorization...');
+  window.location.assign(authorizationUrl);
+});
+
+refreshButton.addEventListener('click', () => {
+  refreshAccessToken().catch(err => log(err.message, true));
+});
+
+clearButton.addEventListener('click', () => {
+  clearSession();
+});
+
+window.addEventListener('load', () => {
+  loadPreferences();
+
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const state = params.get('state');
+
+  if (code) {
+    exchangeAuthorizationCode(code, state).catch(err => log(err.message, true));
+    window.history.replaceState({}, document.title, window.location.pathname);
+  }
+});

--- a/demo/public/style.css
+++ b/demo/public/style.css
@@ -1,0 +1,97 @@
+:root {
+  color-scheme: light dark;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: rgb(16, 16, 16);
+  color: #f4f4f4;
+}
+
+main {
+  max-width: 720px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+section,
+header {
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+  gap: 0.35rem;
+}
+
+input,
+textarea {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  padding: 0.65rem;
+  background: rgba(0, 0, 0, 0.3);
+  color: inherit;
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: none;
+  border-radius: 8px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  background: #06c167;
+  color: #041407;
+  transition: transform 120ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hint {
+  opacity: 0.75;
+  font-size: 0.9rem;
+  margin-top: 0.75rem;
+}
+
+#status-log {
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+#status-log span {
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+  font-size: 0.85rem;
+}

--- a/demo/server.js
+++ b/demo/server.js
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-var-requires, global-require, import/extensions */
+
+const fs = require('node:fs/promises');
+const http = require('node:http');
+const path = require('node:path');
+
+const DEMO_PORT = Number(process.env.DEMO_PORT || 4173);
+const PUBLIC_DIR = path.join(__dirname, 'public');
+
+let Client;
+try {
+  const exported = require('../dist/index.js');
+  Client = exported.default || exported;
+} catch (err) {
+  // eslint-disable-next-line no-console
+  console.error('Unable to load the built client. Please run `npm run build` before starting the demo server.');
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+}
+
+const MIME_TYPES = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+};
+
+async function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', chunk => {
+      data += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        resolve(data ? JSON.parse(data) : {});
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res, status, payload) {
+  res.writeHead(status, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(payload));
+}
+
+async function serveStaticAsset(requestPath, res) {
+  let filePath = path.join(PUBLIC_DIR, requestPath === '/' ? 'index.html' : requestPath);
+  filePath = path.normalize(filePath);
+
+  if (!filePath.startsWith(PUBLIC_DIR)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    const file = await fs.readFile(filePath);
+    const ext = path.extname(filePath);
+    res.writeHead(200, { 'Content-Type': MIME_TYPES[ext] || 'text/plain; charset=utf-8' });
+    res.end(file);
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not found');
+      return;
+    }
+
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Internal server error');
+  }
+}
+
+function createClient(apiKey, apiSecret) {
+  if (!apiKey || !apiSecret) {
+    throw new Error('API key and secret are required.');
+  }
+
+  return new Client(apiKey, apiSecret);
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (req.method === 'POST' && url.pathname === '/api/exchange') {
+    try {
+      const body = await readJsonBody(req);
+      const client = createClient(body.apiKey, body.apiSecret);
+
+      const response = await client.auth.exchangeAuthorizationCode({
+        code: body.code,
+        codeVerifier: body.codeVerifier,
+        redirectUri: body.redirectUri,
+      });
+
+      sendJson(res, response.status, response.data);
+    } catch (err) {
+      sendJson(res, 400, { error: err.message });
+    }
+
+    return;
+  }
+
+  if (req.method === 'POST' && url.pathname === '/api/refresh') {
+    try {
+      const body = await readJsonBody(req);
+      const client = createClient(body.apiKey, body.apiSecret);
+
+      const response = await client.auth.refreshAccessToken(body.refreshToken);
+
+      sendJson(res, response.status, response.data);
+    } catch (err) {
+      sendJson(res, 400, { error: err.message });
+    }
+
+    return;
+  }
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type',
+    });
+    res.end();
+    return;
+  }
+
+  serveStaticAsset(url.pathname, res);
+});
+
+server.listen(DEMO_PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`OAuth demo ready on http://localhost:${DEMO_PORT}`);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@readme/eslint-config": "^14.0.0",
-        "@types/node": "^20.13.0",
+        "@types/node": "^20.19.25",
         "@vitest/coverage-v8": "^1.6.0",
         "eslint": "^8.57.0",
         "fetch-mock": "^9.11.0",
@@ -1288,12 +1288,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.13.0.tgz",
-      "integrity": "sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -6879,10 +6880,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.16",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,12 @@
     "pretest": "npm run lint",
     "prettier": "prettier --check .",
     "prettier:write": "prettier --check --write .",
-    "test": "vitest run --coverage"
+    "test": "vitest run --coverage",
+    "demo": "npm run build && node demo/server.js"
   },
   "devDependencies": {
     "@readme/eslint-config": "^14.0.0",
-    "@types/node": "^20.13.0",
+    "@types/node": "^20.19.25",
     "@vitest/coverage-v8": "^1.6.0",
     "eslint": "^8.57.0",
     "fetch-mock": "^9.11.0",

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,0 +1,72 @@
+import crypto from 'crypto';
+
+export const LETTERBOXD_OAUTH_AUTHORIZE_URL = 'https://letterboxd.com/oauth/authorize';
+
+export type CodeChallengeMethod = 'plain' | 'S256';
+
+export interface AuthorizationUrlOptions {
+  baseUrl?: string;
+  clientId: string;
+  codeChallenge: string;
+  codeChallengeMethod?: CodeChallengeMethod;
+  redirectUri: string;
+  responseType?: 'code';
+  scope?: string[];
+  state?: string;
+}
+
+const BASE64_URL_SAFE = /[+/=]/g;
+
+function encodeBase64Url(buffer: Buffer | Uint8Array) {
+  return Buffer.from(buffer)
+    .toString('base64')
+    .replace(BASE64_URL_SAFE, char => {
+      if (char === '+') return '-';
+      if (char === '/') return '_';
+      return '';
+    });
+}
+
+export function createCodeVerifier(length = 64) {
+  return encodeBase64Url(crypto.randomBytes(length));
+}
+
+export function createCodeChallenge(codeVerifier: string) {
+  return encodeBase64Url(crypto.createHash('sha256').update(codeVerifier).digest());
+}
+
+export function createPkcePair(length = 64) {
+  const codeVerifier = createCodeVerifier(length);
+  const codeChallenge = createCodeChallenge(codeVerifier);
+
+  return { codeVerifier, codeChallenge };
+}
+
+export function buildAuthorizationUrl({
+  baseUrl = LETTERBOXD_OAUTH_AUTHORIZE_URL,
+  clientId,
+  codeChallenge,
+  codeChallengeMethod = 'S256',
+  redirectUri,
+  responseType = 'code',
+  scope,
+  state,
+}: AuthorizationUrlOptions) {
+  const url = new URL(baseUrl);
+
+  url.searchParams.set('response_type', responseType);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', codeChallengeMethod);
+
+  if (scope?.length) {
+    url.searchParams.set('scope', scope.join(' '));
+  }
+
+  if (state) {
+    url.searchParams.set('state', state);
+  }
+
+  return url.toString();
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 import fetchMock from 'fetch-mock';
 import { beforeEach, afterEach, describe, it, expect } from 'vitest';
 
@@ -61,6 +63,90 @@ describe('letterboxd-client', () => {
         });
       });
     });
+
+    describe('.createPkcePair()', () => {
+      it('should create a PKCE pair', () => {
+        const client = new Client(apiKey, apiSecret);
+        const pair = client.auth.createPkcePair();
+
+        expect(pair).toHaveProperty('codeVerifier');
+        expect(pair).toHaveProperty('codeChallenge');
+        expect(pair.codeVerifier.length).toBeGreaterThan(10);
+
+        const expectedChallenge = crypto.createHash('sha256').update(pair.codeVerifier).digest('base64url');
+        expect(pair.codeChallenge).toBe(expectedChallenge);
+      });
+    });
+
+    describe('.buildAuthorizationUrl()', () => {
+      it('should build an OAuth authorization URL', () => {
+        const client = new Client(apiKey, apiSecret);
+        const authorizeUrl = client.auth.buildAuthorizationUrl({
+          authorizationEndpoint: 'https://example.com/oauth/authorize',
+          codeChallenge: 'challenge',
+          redirectUri: 'https://example.com/callback',
+          scope: ['read', 'write'],
+          state: 'state-123',
+        });
+
+        const url = new URL(authorizeUrl);
+        expect(url.origin + url.pathname).toBe('https://example.com/oauth/authorize');
+        expect(Object.fromEntries(url.searchParams.entries())).toStrictEqual({
+          client_id: apiKey,
+          code_challenge: 'challenge',
+          code_challenge_method: 'S256',
+          redirect_uri: 'https://example.com/callback',
+          response_type: 'code',
+          scope: 'read write',
+          state: 'state-123',
+        });
+      });
+    });
+
+    describe('.exchangeAuthorizationCode()', () => {
+      it('should exchange an authorization code for an access token', async () => {
+        const client = new Client(apiKey, apiSecret);
+        const { status, data }: MockedResponse = await client.auth.exchangeAuthorizationCode({
+          code: 'oauth-code',
+          codeVerifier: 'verifier',
+          redirectUri: 'http://localhost:4173/callback',
+        });
+
+        expect(status).toBe(200);
+        expect(data.headers).toHaveProperty('content-type', 'application/x-www-form-urlencoded');
+
+        const url = new URL(data.url);
+        expect(url.pathname).toBe('/api/v0/auth/token');
+
+        const params = Object.fromEntries(url.searchParams.entries());
+        expect(params).toHaveProperty('apikey', apiKey);
+        expect(params).toHaveProperty('nonce');
+        expect(params).toHaveProperty('signature');
+        expect(params).toHaveProperty('timestamp');
+
+        expect(data.body).toBe(
+          'grant_type=authorization_code&code=oauth-code&code_verifier=verifier&redirect_uri=http%3A%2F%2Flocalhost%3A4173%2Fcallback',
+        );
+      });
+    });
+
+    describe('.refreshAccessToken()', () => {
+      it('should refresh an access token', async () => {
+        const client = new Client(apiKey, apiSecret);
+        const { status, data }: MockedResponse = await client.auth.refreshAccessToken('refresh-token');
+
+        expect(status).toBe(200);
+        expect(data.headers).toHaveProperty('content-type', 'application/x-www-form-urlencoded');
+
+        const url = new URL(data.url);
+        expect(url.pathname).toBe('/api/v0/auth/token');
+
+        const params = Object.fromEntries(url.searchParams.entries());
+        expect(params).toHaveProperty('apikey', apiKey);
+
+        expect(data.body).toBe('grant_type=refresh_token&refresh_token=refresh-token');
+      });
+    });
   });
 
   describe('.film', () => {
@@ -91,6 +177,29 @@ describe('letterboxd-client', () => {
           timestamp: expect.stringMatching(/\d{10}/),
         });
       });
+
+      it('should access films with OAuth token without signature', async () => {
+        const client = new Client(apiKey, apiSecret, accessToken);
+        const { status, data }: MockedResponse = await client.film.all({
+          perPage: 1,
+          decade: 1960,
+          sort: 'FilmPopularityThisWeek',
+        });
+
+        expect(status).toBe(200);
+        expect(data.body).toBeUndefined();
+        expect(data.headers).toHaveProperty('authorization', `Bearer ${accessToken}`);
+
+        const url = new URL(data.url);
+        const params = Object.fromEntries(url.searchParams.entries());
+
+        expect(url.pathname).toBe('/api/v0/films');
+        expect(params).toStrictEqual({
+          perPage: '1',
+          decade: '1960',
+          sort: 'FilmPopularityThisWeek',
+        });
+      });
     });
   });
 
@@ -101,7 +210,7 @@ describe('letterboxd-client', () => {
         await expect(client.me.get()).rejects.toThrow(MissingAccessTokenError);
       });
 
-      it('should retrieve my user', async () => {
+      it('should retrieve my user using OAuth token without signature', async () => {
         const client = new Client(apiKey, apiSecret, accessToken);
         const { status, data }: MockedResponse = await client.me.get();
 
@@ -113,12 +222,7 @@ describe('letterboxd-client', () => {
         const params = Object.fromEntries(url.searchParams.entries());
 
         expect(url.pathname).toBe('/api/v0/me');
-        expect(params).toStrictEqual({
-          apikey: apiKey,
-          nonce: expect.stringMatching(/([a-z0-9-]+)/),
-          signature: expect.stringMatching(/([a-z0-9]+)/),
-          timestamp: expect.stringMatching(/\d{10}/),
-        });
+        expect(params).toStrictEqual({});
       });
     });
   });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,12 @@
     "baseUrl": "./src/",
     "declaration": true,
     "esModuleInterop": true,
+    "lib": ["es2017", "dom"],
+    "module": "commonjs",
+    "target": "es2017",
     "noImplicitAny": true,
     "outDir": "./dist",
+    "types": ["node"],
 
     // There's an issue with the types on node-fetch@2 where its `AbortSignal` type now clash
     // with `@types/node`.


### PR DESCRIPTION
| 🌲 Resolves #52 |
| :------------------: |

## 🧰 Changes

This PR introduces first-class support for the OAuth 2.0 Authorization Code Flow with PKCE, providing a more secure and modern way to authenticate users compared to the legacy password grant.

Key changes include:

*   **OAuth Helpers:** Added new methods to `client.auth` (`createPkcePair`, `buildAuthorizationUrl`, `exchangeAuthorizationCode`, `refreshAccessToken`) to simplify the implementation of the OAuth flow.
*   **Flexible Authentication:** Updated the low-level request pipeline to intelligently apply HMAC signatures only when an OAuth bearer token is *not* present (except for `/auth/token` endpoint itself), allowing seamless use of both legacy API key/secret and new OAuth tokens.
*   **Interactive Demo:** Delivered a fully functional demo (`npm run demo`) that showcases the complete OAuth authorization code + PKCE flow in a browser, including PKCE generation, redirection, code exchange, and token refreshing.

## 🧬 QA & Testing

*   **Unit Tests:** Run `npm test` to ensure all existing and new unit tests pass.
*   **OAuth Demo:**
    1.  Run `npm run demo`. This will build the SDK and launch a lightweight Node.js server serving the demo UI at `http://localhost:4173`.
    2.  Follow the instructions on the demo page to walk through the OAuth flow:
        *   Enter your Letterboxd API key/secret and a redirect URI configured for `http://localhost:4173`.
        *   Initiate the flow, approve access on Letterboxd, and observe the token exchange.
        *   Test the "Refresh Access Token" functionality.
        *   Verify that session data is stored in `sessionStorage` and cleared upon closing the tab or clicking "Clear Session".

---
<a href="https://cursor.com/background-agent?bcId=bc-edda6e03-777c-48c6-ac09-f30388e7bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edda6e03-777c-48c6-ac09-f30388e7bd03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

